### PR TITLE
Add more options for documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,12 +36,6 @@ spec = APISpec(chalice_app=app,
                plugins=[PydanticPlugin(), ChalicePlugin()])
 ```
 
-If you use:
-```python
-ChalicePlugin(generate_default_docs=True)
-```
-the plugin will generate empty docs (with empty request and response schemas) for every endpoint that you've defined in your app. This can be useful as a starting point / overview while developing.
-
 ## Usage
 
 To document your API, use your existing Pydantic models and add kwargs to Chalice decorators.
@@ -74,6 +68,56 @@ def example():
     # code goes here
     pass
 ```
+
+## Auto-Generation
+
+### Default Empty Docs
+
+If you use:
+```python
+ChalicePlugin(generate_default_docs=True)
+```
+the plugin will generate empty docs (with empty request and response schemas) for every endpoint that you've defined in your app. This can be useful as a starting point / overview while developing.
+
+### Path Parameters
+
+These are inferred from the path itself. Any identifiers inside curly braces in a path is added as a string path parameter for that path. e.g. for the path `/users/{id}/friends/{f_id}`, the path parameters `id` and `f_id` will be added to the spec.
+
+To disable this behaviour, define your own parameters or set them to an empty list:
+
+```python
+Operation(request=MySchema, response=MyOtherSchema, parameters=[])
+```
+
+### Tags
+
+Tags are used in things like Swagger to group endpoints into logical sets. If you don't supply any tags, chalice-spec will add a tag for each endpoint that is the first segment of the path. e.g. `/users`, `/users/{id}/friends`, and `/users/{id}/posts` will all be tagged with `users`.
+
+To disable this behaviour, define `tags` in your operation (either with the tags you want, or an empty list):
+
+```python
+Operation(request=MySchema, response=MyOtherSchema, tags=[])
+```
+
+### Summary and Description
+
+Endpoint summaries and descriptions are inferred from the route docstring. The first line of the docstring is used as the summary, and all other lines become the description:
+
+```python
+@app.route('/users/{id}', methods=['GET'], docs=Docs(response=UserSchema))
+def get_user(id):
+    """
+    Retrieve a user object.
+    User's can't retrieve other users using this endpoint - only themselves.
+    """
+```
+
+To disable this behaviour, you can define your own summary/description or set them to empty strings:
+
+```python
+Operation(request=MySchema, response=MyOtherSchema, summary='', description='')
+```
+
 
 ### API
 

--- a/chalice_spec/chalice.py
+++ b/chalice_spec/chalice.py
@@ -83,7 +83,7 @@ class ChalicePlugin(BasePlugin):
                     for operation in operations:
                         if (
                             "tags" not in operations[operation]
-                            or not operations[operation]["tags"]
+                            or operations[operation]["tags"] is None
                         ):
                             operations[operation]["tags"] = [
                                 "/" + path.lstrip("/").split("/", 1)[0]
@@ -95,12 +95,12 @@ class ChalicePlugin(BasePlugin):
                         for operation in operations:
                             if (
                                 "summary" not in operations[operation]
-                                or not operations[operation]["summary"]
+                                or operations[operation]["summary"] is None
                             ):
                                 operations[operation]["summary"] = split_docstring[0]
                             if (
                                 "description" not in operations[operation]
-                                or not operations[operation]["description"]
+                                or operations[operation]["description"] is None
                             ) and len(split_docstring) == 2:
                                 operations[operation]["description"] = split_docstring[
                                     1

--- a/chalice_spec/chalice.py
+++ b/chalice_spec/chalice.py
@@ -1,5 +1,4 @@
 import re
-import os
 from apispec import BasePlugin, APISpec
 from pydantic import BaseModel
 

--- a/chalice_spec/chalice.py
+++ b/chalice_spec/chalice.py
@@ -115,7 +115,7 @@ class ChaliceWithSpec(Chalice):
 
             if docs:
                 operations = docs.build_operations(self.__spec, methods)
-                
+
                 # Infer path parameters
                 get_params = r"{([^}]+)}"
                 path_params = []
@@ -166,4 +166,3 @@ class ChaliceWithSpec(Chalice):
             return super(ChaliceWithSpec, self).route(path, **kwargs)(func)
 
         return route_decorator
-

--- a/chalice_spec/chalice.py
+++ b/chalice_spec/chalice.py
@@ -1,14 +1,13 @@
 import re
 
-from chalice_spec.docs import Docs, Operation, trim_docstring
+from chalice_spec.docs import trim_docstring
+from chalice_spec import Docs, Operation
 from typing import Any, Callable, Optional, Union, List
 
 from apispec import APISpec
 from chalice import Blueprint
 from chalice.app import Chalice
 from pydantic import BaseModel
-
-from chalice_spec import Docs, Operation
 
 
 def default_docs_for_methods(methods: List[str]):
@@ -157,7 +156,12 @@ class ChaliceWithSpec(Chalice):
                                 1
                             ].strip()
 
-                self.__spec.path(path, operations=operations, summary=docs.summary)
+                self.__spec.path(
+                    path,
+                    operations=operations,
+                    summary=docs.summary,
+                    parameters=path_params,
+                )
 
             return super(ChaliceWithSpec, self).route(path, **kwargs)(func)
 

--- a/chalice_spec/docs.py
+++ b/chalice_spec/docs.py
@@ -21,6 +21,7 @@ class Operation:
         summary: str = None,
         description: str = None,
         tags: List[str] = None,
+        parameters: List[Dict] = None,
         request: Optional[Type[BaseModel]] = None,
         response: Optional[Union[Response, Type[BaseModel]]] = None,
         responses: Optional[List[Response]] = None,
@@ -28,6 +29,7 @@ class Operation:
         self.summary = summary
         self.description = description
         self.tags = tags
+        self.parameters = parameters
 
         self.request = request
 
@@ -143,6 +145,8 @@ class Docs:
             operation["description"] = method.description
         if method.tags:
             operation["tags"] = method.tags
+        if method.parameters:
+            operation["parameters"] = method.parameters
 
         return operation
 

--- a/chalice_spec/docs.py
+++ b/chalice_spec/docs.py
@@ -1,4 +1,5 @@
-from typing import Type, Optional, Union, List
+import sys
+from typing import Type, Optional, Union, List, Dict
 
 from apispec import APISpec
 from pydantic import BaseModel
@@ -17,10 +18,17 @@ class Response:
 class Operation:
     def __init__(
         self,
+        summary: str = None,
+        description: str = None,
+        tags: List[str] = None,
         request: Optional[Type[BaseModel]] = None,
         response: Optional[Union[Response, Type[BaseModel]]] = None,
         responses: Optional[List[Response]] = None,
     ):
+        self.summary = summary
+        self.description = description
+        self.tags = tags
+
         self.request = request
 
         if response and responses:
@@ -129,6 +137,13 @@ class Docs:
 
             operation["responses"] = responses
 
+        if method.summary:
+            operation["summary"] = method.summary
+        if method.description:
+            operation["description"] = method.description
+        if method.tags:
+            operation["tags"] = method.tags
+
         return operation
 
     @classmethod
@@ -173,3 +188,29 @@ class Docs:
 
 Resp = Response
 Op = Operation
+
+# From: https://peps.python.org/pep-0257/#handling-docstring-indentation
+def trim_docstring(docstring):
+    if not docstring:
+        return ""
+    # Convert tabs to spaces (following the normal Python rules)
+    # and split into a list of lines:
+    lines = docstring.expandtabs().splitlines()
+    # Determine minimum indentation (first line doesn't count):
+    indent = sys.maxsize
+    for line in lines[1:]:
+        stripped = line.lstrip()
+        if stripped:
+            indent = min(indent, len(line) - len(stripped))
+    # Remove indentation (first line is special):
+    trimmed = [lines[0].strip()]
+    if indent < sys.maxsize:
+        for line in lines[1:]:
+            trimmed.append(line[indent:].rstrip())
+    # Strip off trailing and leading blank lines:
+    while trimmed and not trimmed[-1]:
+        trimmed.pop()
+    while trimmed and not trimmed[0]:
+        trimmed.pop(0)
+    # Return a single string:
+    return "\n".join(trimmed)

--- a/chalice_spec/docs.py
+++ b/chalice_spec/docs.py
@@ -193,6 +193,7 @@ class Docs:
 Resp = Response
 Op = Operation
 
+
 # From: https://peps.python.org/pep-0257/#handling-docstring-indentation
 def trim_docstring(docstring):
     if not docstring:

--- a/tests/test_chalice.py
+++ b/tests/test_chalice.py
@@ -364,3 +364,77 @@ def test_contract_violations():
                 Resp(code=200, model=TestSchema),
             ]
         )
+
+
+# Test 8: setting up parameters for the endpoint
+def test_parameters():
+    app, spec = setup_test()
+
+    @app.route(
+        "/post/{id}",
+        methods=["GET"],
+        docs=Docs(response=AnotherSchema),
+    )
+    def get_post():
+        pass
+
+    assert spec.to_dict() == {
+        "paths": {
+            "/post/{id}": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Success",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/AnotherSchema"
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "tags": [
+                        "/post"
+                    ]
+                },
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "required": True
+                    }
+                ]
+            }
+        },
+        "info": {
+            "title": "Test Schema",
+            "version": "0.0.0"
+        },
+        "openapi": "3.0.1",
+        "components": {
+            "schemas": {
+                "AnotherSchema": {
+                    "title": "AnotherSchema",
+                    "type": "object",
+                    "properties": {
+                        "nintendo": {
+                            "title": "Nintendo",
+                            "type": "string"
+                        },
+                        "atari": {
+                            "title": "Atari",
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "nintendo",
+                        "atari"
+                    ]
+                }
+            }
+        }
+    }

--- a/tests/test_chalice.py
+++ b/tests/test_chalice.py
@@ -58,7 +58,8 @@ def test_response_spec():
                                 }
                             },
                         }
-                    }
+                    },
+                    "tags": ["/"]
                 }
             }
         },
@@ -120,6 +121,7 @@ def test_request_response_spec():
                             },
                         }
                     },
+                    "tags": ["/test"]
                 }
             }
         },
@@ -192,6 +194,7 @@ def test_operation():
                             },
                         }
                     },
+                    "tags": ["/ops"]
                 }
             }
         },
@@ -282,6 +285,7 @@ def test_shorthand():
                             },
                         }
                     },
+                    "tags": ["/"]
                 },
                 "put": {
                     "requestBody": {
@@ -303,6 +307,7 @@ def test_shorthand():
                             },
                         }
                     },
+                    "tags": ["/"]
                 },
             }
         },

--- a/tests/test_chalice.py
+++ b/tests/test_chalice.py
@@ -57,7 +57,7 @@ def test_response_spec():
                             },
                         }
                     },
-                    "tags": ["/"]
+                    "tags": ["/"],
                 }
             }
         },
@@ -119,7 +119,7 @@ def test_request_response_spec():
                             },
                         }
                     },
-                    "tags": ["/test"]
+                    "tags": ["/test"],
                 }
             }
         },
@@ -192,7 +192,7 @@ def test_operation():
                             },
                         }
                     },
-                    "tags": ["/ops"]
+                    "tags": ["/ops"],
                 }
             }
         },
@@ -283,7 +283,7 @@ def test_shorthand():
                             },
                         }
                     },
-                    "tags": ["/"]
+                    "tags": ["/"],
                 },
                 "put": {
                     "requestBody": {
@@ -305,7 +305,7 @@ def test_shorthand():
                             },
                         }
                     },
-                    "tags": ["/"]
+                    "tags": ["/"],
                 },
             }
         },
@@ -389,29 +389,22 @@ def test_parameters():
                                         "$ref": "#/components/schemas/AnotherSchema"
                                     }
                                 }
-                            }
+                            },
                         }
                     },
-                    "tags": [
-                        "/post"
-                    ]
+                    "tags": ["/post"],
                 },
                 "parameters": [
                     {
                         "in": "path",
                         "name": "id",
-                        "schema": {
-                            "type": "string"
-                        },
-                        "required": True
+                        "schema": {"type": "string"},
+                        "required": True,
                     }
-                ]
+                ],
             }
         },
-        "info": {
-            "title": "Test Schema",
-            "version": "0.0.0"
-        },
+        "info": {"title": "Test Schema", "version": "0.0.0"},
         "openapi": "3.0.1",
         "components": {
             "schemas": {
@@ -419,20 +412,11 @@ def test_parameters():
                     "title": "AnotherSchema",
                     "type": "object",
                     "properties": {
-                        "nintendo": {
-                            "title": "Nintendo",
-                            "type": "string"
-                        },
-                        "atari": {
-                            "title": "Atari",
-                            "type": "string"
-                        }
+                        "nintendo": {"title": "Nintendo", "type": "string"},
+                        "atari": {"title": "Atari", "type": "string"},
                     },
-                    "required": [
-                        "nintendo",
-                        "atari"
-                    ]
+                    "required": ["nintendo", "atari"],
                 }
             }
-        }
+        },
     }


### PR DESCRIPTION
This PR adds options to populate swagger docs more completely through tags, summaries, descriptions, and path parameters.

I've gone with the philosophy that a package such as chalice-spec should try to do as much as possible automatically, because no one likes writing docs 😄. So by default they will populate all of the below automatically - but the automatic behaviour can be overwritten by setting any of these options on an `Operation` object.

### Path parameters
These are inferred from the path itself. Any identifiers inside curly braces in a path is added as a string path parameter for that path (e.g. for the path `/users/{id}/friends/{f_id}` will add the path parameters `id` and `f_id` to the spec).

### Tags
A tag is added to each operation which is the first section of the path. `/users`, `/users/{id}` and `/users/{id}/friends/{f_id}` will all be tagged with `/users`. This just serves to group endpoints somewhat in the docs.

### Summary and Description
These are simple strings that if not defined in an `Operation` will be inferred from the route function's docstring. The first line of the docstring will be used as the summary, and the rest is used as the description.

I haven't updated chalice-spec docs or anything, I'm interested to hear what you think of the above first.