### PR TITLE
Remove chalice_app from readme example

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,8 +42,7 @@ After:
 from chalice_spec import ChaliceWithSpec, PydanticPlugin
 from apispec import APISpec
 
-spec = APISpec(chalice_app=app,
-               ...,
+spec = APISpec(...,
                plugins=[PydanticPlugin()])
 
 app = ChaliceWithSpec(app_name="hello_world", spec=spec)


### PR DESCRIPTION
I think this is a leftover from the old api?