### PR TITLE
Blueprint should support same features set as standard chalice routes

### DIFF
--- a/chalice_spec/chalice.py
+++ b/chalice_spec/chalice.py
@@ -50,7 +50,7 @@ class BlueprintWithSpec(Blueprint):
 
             self._chalice_spec_docs.append((path, methods, docs, func))
 
-            return super(BlueprintWithSpec, self).route(path, **kwargs)
+            return super(BlueprintWithSpec, self).route(path, **kwargs)(func)
 
         return route_decorator
 

--- a/chalice_spec/chalice.py
+++ b/chalice_spec/chalice.py
@@ -39,18 +39,13 @@ class BlueprintWithSpec(Blueprint):
 
     def __init__(self, import_name: str, generate_default_docs=False) -> None:
         self._chalice_spec_docs = []
-        self.__generate_default_docs = generate_default_docs
         super(BlueprintWithSpec, self).__init__(import_name)
 
     def route(self, path: str, **kwargs: Any) -> Callable[..., Any]:
         docs: Docs = kwargs.pop("docs", None)
 
         methods = [method.lower() for method in kwargs.get("methods", ["get"])]
-        if docs is None and self.__generate_default_docs:
-            docs = default_docs_for_methods(methods)
-
-        if docs:
-            self._chalice_spec_docs.append((path, methods, docs))
+        self._chalice_spec_docs.append((path, methods, docs))
 
         return super(BlueprintWithSpec, self).route(path, **kwargs)
 

--- a/chalice_spec/chalice.py
+++ b/chalice_spec/chalice.py
@@ -37,7 +37,7 @@ class BlueprintWithSpec(Blueprint):
     enable easy OpenAPI documentation.
     """
 
-    def __init__(self, import_name: str, generate_default_docs=False) -> None:
+    def __init__(self, import_name: str) -> None:
         self._chalice_spec_docs = []
         super(BlueprintWithSpec, self).__init__(import_name)
 

--- a/chalice_spec/chalice.py
+++ b/chalice_spec/chalice.py
@@ -37,15 +37,19 @@ class BlueprintWithSpec(Blueprint):
     enable easy OpenAPI documentation.
     """
 
-    def __init__(self, import_name: str) -> None:
+    def __init__(self, import_name: str, generate_default_docs=False) -> None:
         self._chalice_spec_docs = []
+        self.__generate_default_docs = generate_default_docs
         super(BlueprintWithSpec, self).__init__(import_name)
 
     def route(self, path: str, **kwargs: Any) -> Callable[..., Any]:
         docs: Docs = kwargs.pop("docs", None)
 
+        methods = [method.lower() for method in kwargs.get("methods", ["get"])]
+        if docs is None and self.__generate_default_docs:
+            docs = default_docs_for_methods(methods)
+
         if docs:
-            methods = [method.lower() for method in kwargs.get("methods", ["get"])]
             self._chalice_spec_docs.append((path, methods, docs))
 
         return super(BlueprintWithSpec, self).route(path, **kwargs)

--- a/chalice_spec/chalice.py
+++ b/chalice_spec/chalice.py
@@ -82,8 +82,10 @@ class ChaliceWithSpec(Chalice):
         # and so on!
     """
 
-    def __init__(self, app_name: str, spec: APISpec, generate_default_docs=False):
-        super().__init__(app_name)
+    def __init__(
+        self, app_name: str, spec: APISpec, generate_default_docs=False, **kwargs
+    ):
+        super().__init__(app_name, **kwargs)
 
         self.__spec = spec
         self.__generate_default_docs = generate_default_docs

--- a/tests/chalicelib/blueprint_three.py
+++ b/tests/chalicelib/blueprint_three.py
@@ -1,0 +1,10 @@
+from chalice_spec.chalice import BlueprintWithSpec
+
+blueprint_three = BlueprintWithSpec(__name__, generate_default_docs=True)
+
+
+@blueprint_three.route(
+    "/another-world-3/post", methods=["POST"]
+)
+def the_third_blueprint_route():
+    pass

--- a/tests/chalicelib/blueprint_three.py
+++ b/tests/chalicelib/blueprint_three.py
@@ -1,6 +1,6 @@
 from chalice_spec.chalice import BlueprintWithSpec
 
-blueprint_three = BlueprintWithSpec(__name__, generate_default_docs=True)
+blueprint_three = BlueprintWithSpec(__name__)
 
 
 @blueprint_three.route("/another-world-3/post", methods=["POST"])

--- a/tests/chalicelib/blueprint_three.py
+++ b/tests/chalicelib/blueprint_three.py
@@ -1,6 +1,6 @@
 from chalice_spec.chalice import BlueprintWithSpec
 
-blueprint_three = BlueprintWithSpec(__name__)
+blueprint_three = BlueprintWithSpec(__name__, tags=["tag 1"])
 
 
 @blueprint_three.route("/another-world-3/posts/{id}", methods=["POST"])

--- a/tests/chalicelib/blueprint_three.py
+++ b/tests/chalicelib/blueprint_three.py
@@ -3,8 +3,6 @@ from chalice_spec.chalice import BlueprintWithSpec
 blueprint_three = BlueprintWithSpec(__name__, generate_default_docs=True)
 
 
-@blueprint_three.route(
-    "/another-world-3/post", methods=["POST"]
-)
+@blueprint_three.route("/another-world-3/post", methods=["POST"])
 def the_third_blueprint_route():
     pass

--- a/tests/chalicelib/blueprint_three.py
+++ b/tests/chalicelib/blueprint_three.py
@@ -3,6 +3,6 @@ from chalice_spec.chalice import BlueprintWithSpec
 blueprint_three = BlueprintWithSpec(__name__)
 
 
-@blueprint_three.route("/another-world-3/post", methods=["POST"])
+@blueprint_three.route("/another-world-3/posts/{id}", methods=["POST"])
 def the_third_blueprint_route():
     pass

--- a/tests/chalicelib/blueprint_two.py
+++ b/tests/chalicelib/blueprint_two.py
@@ -9,4 +9,5 @@ blueprint_two = BlueprintWithSpec(__name__)
     "/another-world/post", docs=Docs(post=TestSchema), methods=["POST"]
 )
 def the_second_blueprint_route():
+    """this is a docstring"""
     pass

--- a/tests/test_blueprint.py
+++ b/tests/test_blueprint.py
@@ -101,6 +101,55 @@ def test_blueprint_two():
     }
 
 
+def test_blueprint_three():
+    from .chalicelib.blueprint_three import blueprint_three
+
+    app, spec = setup_test()
+    app.register_blueprint(blueprint_three)
+    assert spec.to_dict() == {
+        "paths": {
+            "/another-world-3/post": {
+                "post": {
+                    "requestBody": {
+                        "content": {
+                            "application/json": {
+                                "schema": { 
+                                    "$ref": "#/components/schemas/BaseModel" 
+                                }
+                            }
+                        }
+                    }, 
+                    "responses": {
+                        "200": {
+                            "description": "Success", 
+                            "content": {
+                                "application/json": {
+                                    "schema": { 
+                                        "$ref": "#/components/schemas/BaseModel" 
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }, 
+        "info": {
+            "title": "Test Schema", 
+            "version": "0.0.0"
+        }, 
+        "openapi": "3.0.1", 
+        "components": {
+            "schemas": {
+                "BaseModel": {
+                    "title": "BaseModel", 
+                    "type": "object", 
+                    "properties": {}
+                }
+            }
+        }
+    }
+
 def test_two_blueprints():
     app, spec = setup_test()
 

--- a/tests/test_blueprint.py
+++ b/tests/test_blueprint.py
@@ -4,14 +4,16 @@ from chalice_spec import PydanticPlugin
 from chalice_spec.chalice import ChaliceWithSpec
 
 
-def setup_test():
+def setup_test(generate_default_docs=False):
     spec = APISpec(
         title="Test Schema",
         openapi_version="3.0.1",
         version="0.0.0",
         plugins=[PydanticPlugin()],
     )
-    app = ChaliceWithSpec(app_name="test", spec=spec)
+    app = ChaliceWithSpec(
+        app_name="test", spec=spec, generate_default_docs=generate_default_docs
+    )
     return app, spec
 
 
@@ -101,10 +103,22 @@ def test_blueprint_two():
     }
 
 
-def test_blueprint_three():
+def test_blueprint_three_no_default_docs():
     from .chalicelib.blueprint_three import blueprint_three
 
-    app, spec = setup_test()
+    app, spec = setup_test(generate_default_docs=False)
+    app.register_blueprint(blueprint_three)
+    assert spec.to_dict() == {
+        "paths": {},
+        "info": {"title": "Test Schema", "version": "0.0.0"},
+        "openapi": "3.0.1",
+    }
+
+
+def test_blueprint_three_with_default_docs():
+    from .chalicelib.blueprint_three import blueprint_three
+
+    app, spec = setup_test(generate_default_docs=True)
     app.register_blueprint(blueprint_three)
     assert spec.to_dict() == {
         "paths": {

--- a/tests/test_blueprint.py
+++ b/tests/test_blueprint.py
@@ -27,6 +27,7 @@ def test_blueprint_one():
         "paths": {
             "/prefix/hello-world/deep": {
                 "get": {
+                    "tags": ["/prefix"],
                     "responses": {
                         "200": {
                             "description": "Success",
@@ -38,7 +39,7 @@ def test_blueprint_one():
                                 }
                             },
                         }
-                    }
+                    },
                 }
             }
         },
@@ -70,6 +71,8 @@ def test_blueprint_two():
         "paths": {
             "/another-world/post": {
                 "post": {
+                    "tags": ["/another-world"],
+                    "summary": "this is a docstring",
                     "responses": {
                         "200": {
                             "description": "Success",
@@ -81,7 +84,7 @@ def test_blueprint_two():
                                 }
                             },
                         }
-                    }
+                    },
                 }
             }
         },
@@ -122,8 +125,17 @@ def test_blueprint_three_with_default_docs():
     app.register_blueprint(blueprint_three)
     assert spec.to_dict() == {
         "paths": {
-            "/another-world-3/post": {
+            "/another-world-3/posts/{id}": {
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "required": True,
+                        "schema": {"type": "string"},
+                    }
+                ],
                 "post": {
+                    "tags": ["/another-world-3"],
                     "requestBody": {
                         "content": {
                             "application/json": {
@@ -141,7 +153,7 @@ def test_blueprint_three_with_default_docs():
                             },
                         }
                     },
-                }
+                },
             }
         },
         "info": {"title": "Test Schema", "version": "0.0.0"},
@@ -167,6 +179,7 @@ def test_two_blueprints():
         "paths": {
             "/prefixed/hello-world/deep": {
                 "get": {
+                    "tags": ["/prefixed"],
                     "responses": {
                         "200": {
                             "description": "Success",
@@ -178,11 +191,13 @@ def test_two_blueprints():
                                 }
                             },
                         }
-                    }
+                    },
                 }
             },
             "/another-world/post": {
                 "post": {
+                    "summary": "this is a docstring",
+                    "tags": ["/another-world"],
                     "responses": {
                         "200": {
                             "description": "Success",
@@ -194,7 +209,7 @@ def test_two_blueprints():
                                 }
                             },
                         }
-                    }
+                    },
                 }
             },
         },

--- a/tests/test_blueprint.py
+++ b/tests/test_blueprint.py
@@ -113,42 +113,32 @@ def test_blueprint_three():
                     "requestBody": {
                         "content": {
                             "application/json": {
-                                "schema": { 
-                                    "$ref": "#/components/schemas/BaseModel" 
-                                }
+                                "schema": {"$ref": "#/components/schemas/BaseModel"}
                             }
                         }
-                    }, 
+                    },
                     "responses": {
                         "200": {
-                            "description": "Success", 
+                            "description": "Success",
                             "content": {
                                 "application/json": {
-                                    "schema": { 
-                                        "$ref": "#/components/schemas/BaseModel" 
-                                    }
+                                    "schema": {"$ref": "#/components/schemas/BaseModel"}
                                 }
-                            }
+                            },
                         }
-                    }
+                    },
                 }
             }
-        }, 
-        "info": {
-            "title": "Test Schema", 
-            "version": "0.0.0"
-        }, 
-        "openapi": "3.0.1", 
+        },
+        "info": {"title": "Test Schema", "version": "0.0.0"},
+        "openapi": "3.0.1",
         "components": {
             "schemas": {
-                "BaseModel": {
-                    "title": "BaseModel", 
-                    "type": "object", 
-                    "properties": {}
-                }
+                "BaseModel": {"title": "BaseModel", "type": "object", "properties": {}}
             }
-        }
+        },
     }
+
 
 def test_two_blueprints():
     app, spec = setup_test()

--- a/tests/test_blueprint.py
+++ b/tests/test_blueprint.py
@@ -135,7 +135,7 @@ def test_blueprint_three_with_default_docs():
                     }
                 ],
                 "post": {
-                    "tags": ["/another-world-3"],
+                    "tags": ["tag 1"],
                     "requestBody": {
                         "content": {
                             "application/json": {


### PR DESCRIPTION
The `generate_default_docs=True` settings was already supported on `ChaliceWithSpec`, but was not taken into account when using a blueprint.

This PR fixes that, setting `generate_default_docs=True` on the main `ChaliceWithSpec` instance will generate docs automatically for blueprints.

It also allows other default behaviors to work with blueprints, such as:
- automatic parameters from path
- automatic summary from docstring
- ability to pass tags for a whole blueprint: `blueprint_three = BlueprintWithSpec(__name__, tags=["tag 1"])`

Any comment welcomed!