### PR TITLE
Add support for content types

### DIFF
--- a/chalice_spec/chalice.py
+++ b/chalice_spec/chalice.py
@@ -184,7 +184,7 @@ class ChaliceWithSpec(Chalice):
         def route_decorator(func):
             docs: Docs = kwargs.pop("docs", None)
             methods = [method.lower() for method in kwargs.get("methods", ["get"])]
-            content_types = kwargs.pop("content_types", None)
+            content_types = kwargs.get("content_types", None)
 
             self.decorate(docs, path, methods, content_types, func, None)
 

--- a/tests/chalicelib/blueprint_three.py
+++ b/tests/chalicelib/blueprint_three.py
@@ -3,6 +3,10 @@ from chalice_spec.chalice import BlueprintWithSpec
 blueprint_three = BlueprintWithSpec(__name__, tags=["tag 1"])
 
 
-@blueprint_three.route("/another-world-3/posts/{id}", methods=["POST"])
+@blueprint_three.route(
+    "/another-world-3/posts/{id}",
+    methods=["POST"],
+    content_types=["multipart/form-data"],
+)
 def the_third_blueprint_route():
     pass

--- a/tests/test_blueprint.py
+++ b/tests/test_blueprint.py
@@ -138,7 +138,7 @@ def test_blueprint_three_with_default_docs():
                     "tags": ["tag 1"],
                     "requestBody": {
                         "content": {
-                            "application/json": {
+                            "multipart/form-data": {
                                 "schema": {"$ref": "#/components/schemas/BaseModel"}
                             }
                         }

--- a/tests/test_chalice.py
+++ b/tests/test_chalice.py
@@ -420,3 +420,136 @@ def test_parameters():
             }
         },
     }
+
+
+# Test 9: different content_types
+def test_content_types():
+    app, spec = setup_test()
+
+    @app.route(
+        "/posts",
+        methods=["POST"],
+        content_types=["multipart/form-data"],
+        docs=Docs(request=TestSchema, response=AnotherSchema),
+    )
+    def get_post():
+        pass
+
+    assert spec.to_dict() == {
+        "paths": {
+            "/posts": {
+                "post": {
+                    "requestBody": {
+                        "content": {
+                            "multipart/form-data": {
+                                "schema": {"$ref": "#/components/schemas/TestSchema"}
+                            }
+                        }
+                    },
+                    "responses": {
+                        "200": {
+                            "description": "Success",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/AnotherSchema"
+                                    }
+                                }
+                            },
+                        }
+                    },
+                    "tags": ["/posts"],
+                }
+            }
+        },
+        "info": {"title": "Test Schema", "version": "0.0.0"},
+        "openapi": "3.0.1",
+        "components": {
+            "schemas": {
+                "TestSchema": {
+                    "title": "TestSchema",
+                    "type": "object",
+                    "properties": {
+                        "hello": {"title": "Hello", "type": "string"},
+                        "world": {"title": "World", "type": "integer"},
+                    },
+                    "required": ["hello", "world"],
+                },
+                "AnotherSchema": {
+                    "title": "AnotherSchema",
+                    "type": "object",
+                    "properties": {
+                        "nintendo": {"title": "Nintendo", "type": "string"},
+                        "atari": {"title": "Atari", "type": "string"},
+                    },
+                    "required": ["nintendo", "atari"],
+                },
+            }
+        },
+    }
+
+
+def test_content_types_with_operation():
+    app, spec = setup_test()
+
+    @app.route(
+        "/posts",
+        methods=["POST"],
+        content_types=["multipart/form-data"],
+        docs=Docs(post=Op(request=TestSchema, response=AnotherSchema)),
+    )
+    def get_post():
+        pass
+
+    assert spec.to_dict() == {
+        "paths": {
+            "/posts": {
+                "post": {
+                    "requestBody": {
+                        "content": {
+                            "multipart/form-data": {
+                                "schema": {"$ref": "#/components/schemas/TestSchema"}
+                            }
+                        }
+                    },
+                    "responses": {
+                        "200": {
+                            "description": "Success",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/AnotherSchema"
+                                    }
+                                }
+                            },
+                        }
+                    },
+                    "tags": ["/posts"],
+                }
+            }
+        },
+        "info": {"title": "Test Schema", "version": "0.0.0"},
+        "openapi": "3.0.1",
+        "components": {
+            "schemas": {
+                "TestSchema": {
+                    "title": "TestSchema",
+                    "type": "object",
+                    "properties": {
+                        "hello": {"title": "Hello", "type": "string"},
+                        "world": {"title": "World", "type": "integer"},
+                    },
+                    "required": ["hello", "world"],
+                },
+                "AnotherSchema": {
+                    "title": "AnotherSchema",
+                    "type": "object",
+                    "properties": {
+                        "nintendo": {"title": "Nintendo", "type": "string"},
+                        "atari": {"title": "Atari", "type": "string"},
+                    },
+                    "required": ["nintendo", "atari"],
+                },
+            }
+        },
+    }


### PR DESCRIPTION
Content-types can be specified when defining chalice routes:

```
@app.route("/posts", methods=["POST"], content_types=["multipart/form-data"], docs=Docs(request=TestSchema, response=AnotherSchema))

@blueprint.route("/path", methods=["POST"], content_types=["multipart/form-data"])
```

This PR adds support for them, defining them in the specs requestBody.