### PR TITLE
Add security specifications to API Operations

### DIFF
--- a/chalice_spec/docs.py
+++ b/chalice_spec/docs.py
@@ -37,6 +37,7 @@ class Operation:
         request: Optional[Type[BaseModel]] = None,
         response: Optional[Union[Response, Type[BaseModel]]] = None,
         responses: Optional[List[Response]] = None,
+        security: Optional[List[Dict[str, List[str]]]] = None,
     ):
         self.summary = summary
         self.description = description
@@ -45,6 +46,7 @@ class Operation:
 
         self.content_types = content_types
         self.request = request
+        self.security = security
 
         if response and responses:
             raise TypeError("You must only pass one of response or responses")
@@ -176,6 +178,8 @@ class Docs:
             operation["tags"] = method.tags
         if method.parameters:
             operation["parameters"] = method.parameters
+        if method.security:
+            operation["security"] = method.security
 
         return operation
 

--- a/tests/test_chalice.py
+++ b/tests/test_chalice.py
@@ -553,3 +553,86 @@ def test_content_types_with_operation():
             }
         },
     }
+
+
+# Test 10: test security
+def test_security():
+    app, spec = setup_test()
+    bearer_auth = {"type": "http", "scheme": "bearer"}
+    spec.components.security_scheme("BearerAuth", bearer_auth)
+
+    @app.route(
+        "/security",
+        methods=["POST"],
+        docs=Docs(
+            post=Op(
+                request=AnotherSchema,
+                response=Resp(
+                    code=201, description="Updated successfully!", model=TestSchema
+                ),
+                security=[{"BearerAuth": []}]
+            )
+        ),
+    )
+    def test():
+        pass
+
+    assert spec.to_dict() == {
+        "paths": {
+            "/security": {
+                "post": {
+                    "requestBody": {
+                        "content": {
+                            "application/json": {
+                                "schema": {"$ref": "#/components/schemas/AnotherSchema"}
+                            }
+                        }
+                    },
+                    "security": [{"BearerAuth": []}],
+                    "tags": ["/security"],
+                    "responses": {
+                        "201": {
+                            "description": "Updated successfully!",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/TestSchema"
+                                    }
+                                }
+                            },
+                        }
+                    },
+                }
+            }
+        },
+        "info": {"title": "Test Schema", "version": "0.0.0"},
+        "openapi": "3.0.1",
+        "components": {
+            "schemas": {
+                "AnotherSchema": {
+                    "title": "AnotherSchema",
+                    "type": "object",
+                    "properties": {
+                        "nintendo": {"title": "Nintendo", "type": "string"},
+                        "atari": {"title": "Atari", "type": "string"},
+                    },
+                    "required": ["nintendo", "atari"],
+                },
+                "TestSchema": {
+                    "title": "TestSchema",
+                    "type": "object",
+                    "properties": {
+                        "hello": {"title": "Hello", "type": "string"},
+                        "world": {"title": "World", "type": "integer"},
+                    },
+                    "required": ["hello", "world"],
+                },
+            },
+            "securitySchemes": {
+                "BearerAuth": {
+                    "type": "http",
+                    "scheme": "bearer"
+                }
+            }
+        },
+    }


### PR DESCRIPTION
Allow users to specify Security specifications to their APIs

Before:
<img width="1485" alt="Screenshot 2023-05-16 at 7 22 16 PM" src="https://github.com/TestBoxLab/chalice-spec/assets/88190553/4226fb14-1f9b-411c-a29e-2fb6acdf93ae">

After:
<img width="1485" alt="Screenshot 2023-05-16 at 7 23 02 PM" src="https://github.com/TestBoxLab/chalice-spec/assets/88190553/0d67e6d2-ae61-438b-90cc-d3b1d55169fa">

<img width="1485" alt="Screenshot 2023-05-16 at 7 23 18 PM" src="https://github.com/TestBoxLab/chalice-spec/assets/88190553/0a067e84-6984-4934-af44-1616fc87aeab">

Code implementation 

```python

from apispec import APISpec
from chalice_spec import ChaliceWithSpec, Docs, Operation, PydanticPlugin, Response

spec = APISpec(
    title="Spec", version="1.0.0", 
    openapi_version="3.0.2", plugins=[PydanticPlugin()]
)
bearer_auth = {"type": "http", "scheme": "bearer"}
spec.components.security_scheme("Auth", bearer_auth)

@app.route('/healthcheck', methods=['GET'], cors=True,
  docs=Docs(
    get=Operation(
      tags=['Health Check'], responses=[Response(code=HTTPStatus.OK, model=HealthCheckResponse)],
      description="Healthcheck endpoint, returns 'healthy' if service is online",
      summary="Healthcheck endpoint", security=[{"Auth": []}]
    )
  )
)
def healthcheck():
    return {'status': 'healthy'}
```

