### PR TITLE
Add response content_type(s)

### DIFF
--- a/chalice_spec/docs.py
+++ b/chalice_spec/docs.py
@@ -16,7 +16,13 @@ class Response:
     and an optional description.
     """
 
-    def __init__(self, model: type, code: int = 200, description: str = "Success", content_type: str = DEFAULT_CONTENT_TYPE):
+    def __init__(
+            self,
+            model: type,
+            code: int = 200,
+            description: str = "Success",
+            content_type: str = DEFAULT_CONTENT_TYPE
+    ):
         self.model = model
         self.code = code
         self.description = description
@@ -64,7 +70,9 @@ class Operation:
             self.responses = {response.code: {DEFAULT_CONTENT_TYPE: response}}
         else:
             # If not, we will use sensible defaults
-            self.responses = {DEFAULT_CODE: {DEFAULT_CONTENT_TYPE: Response(model=response)}}
+            self.responses = {
+                DEFAULT_CODE: {DEFAULT_CONTENT_TYPE: Response(model=response)}
+            }
 
     def _populate_responses(self, responses: List[Response]):
         self.responses = {}
@@ -72,7 +80,9 @@ class Operation:
             if response.code not in self.responses:
                 self.responses[response.code] = {}
             if response.content_type in self.responses[response.code]:
-                raise TypeError(f"Multiple responses defined for {response.code} — {response.content_type}")
+                raise TypeError(
+                    f"Multiple responses defined for {response.code} — {response.content_type}"
+                )
             self.responses[response.code][response.content_type] = response
 
 

--- a/chalice_spec/docs.py
+++ b/chalice_spec/docs.py
@@ -17,11 +17,11 @@ class Response:
     """
 
     def __init__(
-            self,
-            model: type,
-            code: int = 200,
-            description: str = "Success",
-            content_type: str = DEFAULT_CONTENT_TYPE
+        self,
+        model: type,
+        code: int = 200,
+        description: str = "Success",
+        content_type: str = DEFAULT_CONTENT_TYPE,
     ):
         self.model = model
         self.code = code
@@ -177,7 +177,7 @@ class Docs:
                             "description": response.description,
                             "content": {},
                         }
-                    responses[code]['content'][content_type] = {
+                    responses[code]["content"][content_type] = {
                         "schema": response.model.__name__
                     }
 

--- a/tests/test_chalice.py
+++ b/tests/test_chalice.py
@@ -421,6 +421,7 @@ def test_parameters():
         },
     }
 
+
 # Test 9: different content_types
 def test_content_types():
     app, spec = setup_test()
@@ -436,7 +437,7 @@ def test_content_types():
             request=TestSchema,
             responses=[
                 Resp(model=AnotherSchema, content_type="application/json"),
-                Resp(model=AnotherSchema, content_type="application/xml")
+                Resp(model=AnotherSchema, content_type="application/xml"),
             ],
         ),
     )
@@ -467,7 +468,7 @@ def test_content_types():
                                     "schema": {
                                         "$ref": "#/components/schemas/AnotherSchema"
                                     }
-                                }
+                                },
                             },
                         }
                     },

--- a/tests/test_chalice.py
+++ b/tests/test_chalice.py
@@ -432,7 +432,13 @@ def test_content_types():
         "/posts",
         methods=["POST"],
         content_types=["multipart/form-data"],
-        docs=Docs(request=TestSchema, responses=[Resp(model=AnotherSchema, content_type="application/json"), Resp(model=AnotherSchema, content_type="application/xml")]),
+        docs=Docs(
+            request=TestSchema,
+            responses=[
+                Resp(model=AnotherSchema, content_type="application/json"),
+                Resp(model=AnotherSchema, content_type="application/xml")
+            ],
+        ),
     )
     def get_post():
         pass

--- a/tests/test_chalice.py
+++ b/tests/test_chalice.py
@@ -421,16 +421,18 @@ def test_parameters():
         },
     }
 
-
 # Test 9: different content_types
 def test_content_types():
     app, spec = setup_test()
+
+    with pytest.raises(TypeError):
+        Op(responses=[Resp(model=TestSchema), Resp(model=TestSchema)])
 
     @app.route(
         "/posts",
         methods=["POST"],
         content_types=["multipart/form-data"],
-        docs=Docs(request=TestSchema, response=AnotherSchema),
+        docs=Docs(request=TestSchema, responses=[Resp(model=AnotherSchema, content_type="application/json"), Resp(model=AnotherSchema, content_type="application/xml")]),
     )
     def get_post():
         pass
@@ -451,6 +453,11 @@ def test_content_types():
                             "description": "Success",
                             "content": {
                                 "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/AnotherSchema"
+                                    }
+                                },
+                                "application/xml": {
                                     "schema": {
                                         "$ref": "#/components/schemas/AnotherSchema"
                                     }


### PR DESCRIPTION
OpenAPI let responses have multiple response_types, as per https://swagger.io/docs/specification/describing-responses/ 

This PR adds:
- a new `content_type` in the response object, with a default to `application/json` (the default used before)
- the ability to pass several responses for the same response code, BUT with a different content_type (passing two responses with the same code + content type would raise an error, as we did before when passing two responses with the same code)

The only "issue" I see is that the response description is taken from the first response. I initially wanted to modify the response object to 
```diff
class Response:
-    def __init__(self, model: type, code: int = 200, description: str = "Success", content_type: str = DEFAULT_CONTENT_TYPE):
+    def __init__(self, code: int = 200, content, description: str = "Success"):
-        self.model = model
        self.code = code
        self.description = description
+        self.content = content # content would be an array of {content_types: str, model: type}
```
But I feel that this would change too much the current behavior, so I preferred to "duplicate" the "description" field. I am of course open to discussion on this point !