### PR TITLE
Add support for Pydantic V2 x OpenAPI 3

### DIFF
--- a/chalice_spec/chalice.py
+++ b/chalice_spec/chalice.py
@@ -10,6 +10,10 @@ from chalice.app import Chalice
 from pydantic import BaseModel
 
 
+class EmptyModel(BaseModel):
+    pass
+
+
 def default_docs_for_methods(
     methods: List[str], content_types: Optional[List[str]] = None
 ):
@@ -22,11 +26,11 @@ def default_docs_for_methods(
         **{
             method: Operation(
                 content_types=content_types,
-                response=BaseModel,
+                response=EmptyModel,
                 request=(
                     None
                     if method in ["get", "delete", "head", "options"]
-                    else BaseModel
+                    else EmptyModel
                 ),
             )
             for method in methods

--- a/chalice_spec/pydantic.py
+++ b/chalice_spec/pydantic.py
@@ -32,15 +32,16 @@ class PydanticPlugin(BasePlugin):
 
             # If the spec has passed, we probably have nested models to contend with.
             spec: Union[APISpec, None] = kwargs.pop("spec", None)
-            if spec and "definitions" in schema:
-                for k, v in schema["definitions"].items():
-                    try:
-                        spec.components.schema(k, v)
-                    except DuplicateComponentNameError:
-                        pass
+            for key in ("definitions", "$defs"):
+                if spec and key in schema:
+                    for k, v in schema[key].items():
+                        try:
+                            spec.components.schema(k, v)
+                        except DuplicateComponentNameError:
+                            pass
 
-            if "definitions" in schema:
-                del schema["definitions"]
+                if key in schema:
+                    del schema[key]
 
             return schema
 

--- a/tests/test_blueprint.py
+++ b/tests/test_blueprint.py
@@ -139,7 +139,7 @@ def test_blueprint_three_with_default_docs():
                     "requestBody": {
                         "content": {
                             "multipart/form-data": {
-                                "schema": {"$ref": "#/components/schemas/BaseModel"}
+                                "schema": {"$ref": "#/components/schemas/EmptyModel"}
                             }
                         }
                     },
@@ -148,7 +148,7 @@ def test_blueprint_three_with_default_docs():
                             "description": "Success",
                             "content": {
                                 "application/json": {
-                                    "schema": {"$ref": "#/components/schemas/BaseModel"}
+                                    "schema": {"$ref": "#/components/schemas/EmptyModel"}
                                 }
                             },
                         }
@@ -160,7 +160,7 @@ def test_blueprint_three_with_default_docs():
         "openapi": "3.0.1",
         "components": {
             "schemas": {
-                "BaseModel": {"title": "BaseModel", "type": "object", "properties": {}}
+                "EmptyModel": {"title": "EmptyModel", "type": "object", "properties": {}}
             }
         },
     }


### PR DESCRIPTION
Solves https://github.com/TestBoxLab/chalice-spec/issues/18

Pydantic V2 uses `$defs` key in its schema. This adds support for the new key while still working with the old `definitions` key.

Credit to https://github.com/kkirsche/apispec-pydantic-plugin and I think their repo should be integrated with this repo as it provides a more up-to-date Pydantic plugin for APISpec. But while that happens, it would be great if this fix could go forward to make it possible for the package to be used with Pydantic V2.

Additionally, this also fixes the tests not running. Pydantic does not allow calling the `schema` on the `BaseModel` directly, only on subclasses.